### PR TITLE
Load Scheduled and Migrations only in CLI mode.

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -60,8 +60,11 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     public function boot(): void
     {
-        $this->loadCommandSchedule();
-        $this->loadMigrations();
+        if ($this->app->runningInConsole()) {
+            $this->loadCommandSchedule();
+            $this->loadMigrations();
+        }
+
         $this->loadViews();
         $this->loadTranslations();
         $this->loadConfigs();

--- a/src/Module.php
+++ b/src/Module.php
@@ -47,8 +47,6 @@ abstract class Module extends ServiceProvider implements ModuleContract
     {
         // Register this module in the repository
         app(ModuleRepositoryContract::class)->register($this->getModuleNamespace(), $this->getModulePath());
-
-        $this->registerCommands();
     }
 
     /**
@@ -61,6 +59,7 @@ abstract class Module extends ServiceProvider implements ModuleContract
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
+            $this->registerCommands();
             $this->loadCommandSchedule();
             $this->loadMigrations();
         }


### PR DESCRIPTION
This speeds up the page loads a little for non-cli requests. Neither commands schedules and migrations are used in web requests, so they don't have to be loaded.

Example comparison on the CRM Dashboard:
<img width="348" alt="Screen Shot 2019-12-21 at 17 09 36" src="https://user-images.githubusercontent.com/360150/71310459-b43c0680-2414-11ea-8860-c5f93b4cc919.png">

Another improvement for later would be to do the `registerCommands()` call only on CLI calls.