### PR TITLE
Drop support for old Laravel versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": "^7.2.5",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0"
+        "php": "^7.4|^8.0",
+        "illuminate/console": "^8.0",
+        "illuminate/database": "^8.0",
+        "illuminate/support": "^8.0",
+        "illuminate/routing": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^8.0",
+        "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^4.0"
+        "orchestra/testbench": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": "^1.4",
         "orchestra/testbench": "^6.0"
     },
     "autoload": {

--- a/src/Module.php
+++ b/src/Module.php
@@ -26,13 +26,13 @@ abstract class Module extends ServiceProvider implements ModuleContract
         'api',
     ];
 
-    protected array $policies;
+    protected array $policies = [];
 
-    protected array $middleware;
+    protected array $middleware = [];
 
-    protected array $listen;
+    protected array $listen = [];
 
-    protected array $subscribe;
+    protected array $subscribe = [];
 
     protected string $modulePath;
 
@@ -85,7 +85,6 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     /**
      * @return void
-     * @throws ReflectionException
      */
     protected function loadMigrations(): void
     {
@@ -98,7 +97,6 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     /**
      * @return void
-     * @throws ReflectionException
      */
     protected function loadViews(): void
     {
@@ -111,7 +109,6 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     /**
      * @return void
-     * @throws ReflectionException
      */
     protected function loadTranslations(): void
     {
@@ -124,7 +121,6 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     /**
      * @return void
-     * @throws ReflectionException
      */
     protected function loadConfigs(): void
     {

--- a/src/Module.php
+++ b/src/Module.php
@@ -3,7 +3,6 @@
 namespace Zonneplan\ModuleLoader;
 
 use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
@@ -22,28 +21,23 @@ use Zonneplan\ModuleLoader\Support\Contracts\ModuleRepositoryContract;
 abstract class Module extends ServiceProvider implements ModuleContract
 {
     protected const ROUTE_FILE_TYPES = [
-        'routes', 'web', 'api',
+        'routes',
+        'web',
+        'api',
     ];
 
-    /** @var array */
-    protected $policies = [];
+    protected array $policies;
 
-    /** @var array */
-    protected $middleware = [];
+    protected array $middleware;
 
-    /** @var array */
-    protected $listen = [];
+    protected array $listen;
 
-    /** @var array */
-    protected $subscribe = [];
+    protected array $subscribe;
 
-    /** @var string */
-    protected $modulePath;
+    protected string $modulePath;
 
     /**
      * Register the module.
-     *
-     * @throws ReflectionException
      *
      * @return void
      */
@@ -56,9 +50,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
     /**
      * Boot the module.
      *
-     * @throws ReflectionException
-     *
      * @return void
+     * @throws ReflectionException
      */
     public function boot(): void
     {
@@ -91,9 +84,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
     }
 
     /**
-     * @throws ReflectionException
-     *
      * @return void
+     * @throws ReflectionException
      */
     protected function loadMigrations(): void
     {
@@ -105,9 +97,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
     }
 
     /**
-     * @throws ReflectionException
-     *
      * @return void
+     * @throws ReflectionException
      */
     protected function loadViews(): void
     {
@@ -119,9 +110,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
     }
 
     /**
-     * @throws ReflectionException
-     *
      * @return void
+     * @throws ReflectionException
      */
     protected function loadTranslations(): void
     {
@@ -133,9 +123,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
     }
 
     /**
-     * @throws ReflectionException
-     *
      * @return void
+     * @throws ReflectionException
      */
     protected function loadConfigs(): void
     {
@@ -180,8 +169,6 @@ abstract class Module extends ServiceProvider implements ModuleContract
     }
 
     /**
-     * @throws ReflectionException
-     *
      * @return string
      */
     protected function getModulePath(): string
@@ -246,9 +233,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     private function registerFactories(): void
     {
-        $this->app->afterResolving(Factory::class, function (Factory $faker) {
-            $faker->load($this->getModulePath().'/Database/Factories');
-        });
+        // Unfortunately Laravel 8 no longer supports loading factories like this
+        // because they want you to use ModelFactories.
     }
 
     private function registerRoutes(): void

--- a/src/Support/ModuleRepository.php
+++ b/src/Support/ModuleRepository.php
@@ -13,7 +13,7 @@ use Zonneplan\ModuleLoader\Support\Exceptions\ModuleNotFoundException;
 class ModuleRepository implements ModuleRepositoryContract
 {
     /** @var array */
-    protected $modules = [];
+    protected array $modules = [];
 
     /**
      * Registers a new module with a path.

--- a/src/Support/ModuleRepository.php
+++ b/src/Support/ModuleRepository.php
@@ -12,7 +12,6 @@ use Zonneplan\ModuleLoader\Support\Exceptions\ModuleNotFoundException;
  */
 class ModuleRepository implements ModuleRepositoryContract
 {
-    /** @var array */
     protected array $modules = [];
 
     /**


### PR DESCRIPTION
Changes:
- Add support for PHP 8
- Make use of some PHP 7.4 features

Breaking changes:
- Factory loading is no longer possible due to Laravel 8's new model factories
- Drop support for Laravel 6 & 7
- Drop support for PHP 7.2 & 7.3