### PR TITLE
Support Laravel 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ phpunit.xml
 .env
 .idea
 .phpunit.result.cache
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 [![Build Status](https://img.shields.io/travis/zonneplan/laravel-module-loader/master.svg?style=flat-square)](https://travis-ci.org/zonneplan/laravel-module-loader)
 [![Total Downloads](https://img.shields.io/packagist/dt/zonneplan/laravel-module-loader.svg?style=flat-square)](https://packagist.org/packages/zonneplan/laravel-module-loader)
 
+| **Laravel**  | **laravel-module-loader** |
+|---|---------------------------|
+| 5.8  | ^1.0                      |
+| 6.0  | ^1.0                      |
+| 7.0  | ^1.0                      |
+| 8.0  | ^2.0                      |
+| 9.0  | ^3.0                      |
+
 The `zonneplan/laravel-module-loader` package provides an easy to use module loader 
 which can be used to modulize your project.
 

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/console": "^8.0",
-        "illuminate/database": "^8.0",
-        "illuminate/support": "^8.0",
-        "illuminate/routing": "^8.0"
+        "php": "^8.0",
+        "illuminate/console": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/support": "^9.0",
+        "illuminate/routing": "^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.0"
+        "orchestra/testbench": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Module.php
+++ b/src/Module.php
@@ -36,7 +36,7 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     protected ?string $modulePath = null;
 
-    protected bool $disableAutomaticFactoryLoading = false;
+    protected bool $enableLegacyFactoryLoading = false;
 
     /**
      * Register the module.
@@ -232,7 +232,7 @@ abstract class Module extends ServiceProvider implements ModuleContract
     private function registerFactories(): void
     {
         if (
-            $this->disableAutomaticFactoryLoading === false &&
+            $this->enableLegacyFactoryLoading &&
             method_exists($this, 'loadFactoriesFrom') &&
             file_exists($this->getModulePath().'/Database/Factories')
         ) {

--- a/src/Module.php
+++ b/src/Module.php
@@ -36,6 +36,8 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     protected ?string $modulePath = null;
 
+    protected bool $disableAutomaticFactoryLoading = false;
+
     /**
      * Register the module.
      *
@@ -230,6 +232,7 @@ abstract class Module extends ServiceProvider implements ModuleContract
     private function registerFactories(): void
     {
         if (
+            $this->disableAutomaticFactoryLoading === false &&
             method_exists($this, 'loadFactoriesFrom') &&
             file_exists($this->getModulePath().'/Database/Factories')
         ) {

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -17,9 +17,7 @@ class ModulesServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->singleton(ModuleRepositoryContract::class, static function () {
-            return new ModuleRepository();
-        });
+        $this->app->singleton(ModuleRepositoryContract::class, ModuleRepository::class);
     }
 
     /**

--- a/tests/Support/ModuleRepositoryTest.php
+++ b/tests/Support/ModuleRepositoryTest.php
@@ -4,12 +4,12 @@ namespace Zonneplan\ModuleLoader\Test\Support;
 
 use Zonneplan\ModuleLoader\Support\Contracts\ModuleRepositoryContract;
 use Zonneplan\ModuleLoader\Support\Exceptions\ModuleNotFoundException;
+use Zonneplan\ModuleLoader\Support\ModuleRepository;
 use Zonneplan\ModuleLoader\Test\TestCase;
 
 class ModuleRepositoryTest extends TestCase
 {
-    /* @var ModuleRepository */
-    protected $moduleRepository;
+    protected ModuleRepository $moduleRepository;
 
     public function setUp(): void
     {


### PR DESCRIPTION
With this PR we support Laravel 9. I also added an option to disable loading legacy factories in modules since the new factories break when loaded by the legacy factories option.

This will be 3.0 since it drops support for Laravel 8.