### PR TITLE
Feature/add or use caching when available

### DIFF
--- a/src/Console/ModuleCacheCommand.php
+++ b/src/Console/ModuleCacheCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Console;
+
+use Illuminate\Console\Command;
+use Zonneplan\ModuleLoader\Support\Contracts\ModuleRepositoryContract;
+use Zonneplan\ModuleLoader\Support\ModuleManifest;
+use Zonneplan\ModuleLoader\Support\ModuleRepository;
+
+class ModuleCacheCommand extends Command
+{
+    protected $signature = 'module:cache';
+
+    protected $description = 'Create a cache file for faster module loading';
+
+    public function handle(ModuleManifest $manifest, ModuleRepositoryContract $repository): void
+    {
+        /** @var ModuleRepository $repository */
+        $manifest->clear();
+
+        $modules = $manifest->build($repository);
+
+        $manifest->write($modules);
+
+        $this->components->info(
+            sprintf('Module manifest cached successfully. [%d modules]', count($modules))
+        );
+    }
+}

--- a/src/Console/ModuleClearCommand.php
+++ b/src/Console/ModuleClearCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Console;
+
+use Illuminate\Console\Command;
+use Zonneplan\ModuleLoader\Support\ModuleManifest;
+
+class ModuleClearCommand extends Command
+{
+    protected $signature = 'module:clear';
+
+    protected $description = 'Remove the module cache file';
+
+    public function handle(ModuleManifest $manifest): void
+    {
+        $manifest->clear();
+
+        $this->components->info('Module cache cleared successfully.');
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -126,6 +126,10 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     protected function loadConfigs(): void
     {
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         $configPath = sprintf('%s/Config', $this->getModulePath());
         $configFilePattern = sprintf('%s/*.php', $configPath);
 
@@ -242,6 +246,10 @@ abstract class Module extends ServiceProvider implements ModuleContract
 
     private function registerRoutes(): void
     {
+        if ($this->app->routesAreCached()) {
+            return;
+        }
+
         $routePath = sprintf('%s/Routes', $this->getModulePath());
         $routeFilePattern = sprintf('%s/*.php', $routePath);
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -11,6 +11,7 @@ use ReflectionClass;
 use ReflectionException;
 use Zonneplan\ModuleLoader\Support\Contracts\ModuleContract;
 use Zonneplan\ModuleLoader\Support\Contracts\ModuleRepositoryContract;
+use Zonneplan\ModuleLoader\Support\ModuleManifest;
 
 /**
  * Class ModuleLoader.
@@ -37,6 +38,10 @@ abstract class Module extends ServiceProvider implements ModuleContract
     protected ?string $modulePath = null;
 
     protected bool $enableLegacyFactoryLoading = false;
+
+    private ?array $cachedManifest = null;
+
+    private bool $manifestLoaded = false;
 
     /**
      * Register the module.
@@ -90,6 +95,16 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     protected function loadMigrations(): void
     {
+        $manifest = $this->getManifest();
+
+        if ($manifest !== null) {
+            if ($manifest['migrations'] !== null) {
+                $this->loadMigrationsFrom($manifest['migrations']);
+            }
+
+            return;
+        }
+
         $file = "{$this->getModulePath()}/Database/Migrations";
 
         if (file_exists($file)) {
@@ -102,6 +117,16 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     protected function loadViews(): void
     {
+        $manifest = $this->getManifest();
+
+        if ($manifest !== null) {
+            if ($manifest['views'] !== null) {
+                $this->loadViewsFrom($manifest['views'], $this->getModuleNamespace());
+            }
+
+            return;
+        }
+
         $file = "{$this->getModulePath()}/Resources/views";
 
         if (file_exists($file)) {
@@ -114,6 +139,16 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     protected function loadTranslations(): void
     {
+        $manifest = $this->getManifest();
+
+        if ($manifest !== null) {
+            if ($manifest['translations'] !== null) {
+                $this->loadTranslationsFrom($manifest['translations'], $this->getModuleNamespace());
+            }
+
+            return;
+        }
+
         $file = "{$this->getModulePath()}/Resources/lang";
 
         if (file_exists($file)) {
@@ -127,6 +162,19 @@ abstract class Module extends ServiceProvider implements ModuleContract
     protected function loadConfigs(): void
     {
         if (app()->configurationIsCached()) {
+            return;
+        }
+
+        $manifest = $this->getManifest();
+
+        if ($manifest !== null) {
+            foreach ($manifest['configs'] as $file) {
+                $filename = pathinfo($file, PATHINFO_FILENAME);
+                $configKey = "{$this->getModuleNamespace()}.$filename";
+
+                $this->mergeConfigFrom($file, $configKey);
+            }
+
             return;
         }
 
@@ -235,18 +283,44 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     private function registerFactories(): void
     {
-        if (
-            $this->enableLegacyFactoryLoading &&
-            method_exists($this, 'loadFactoriesFrom') &&
-            file_exists($this->getModulePath().'/Database/Factories')
-        ) {
-            $this->loadFactoriesFrom($this->getModulePath().'/Database/Factories');
+        if (!$this->enableLegacyFactoryLoading || !method_exists($this, 'loadFactoriesFrom')) {
+            return;
+        }
+
+        $manifest = $this->getManifest();
+
+        if ($manifest !== null) {
+            if ($manifest['factories'] !== null) {
+                $this->loadFactoriesFrom($manifest['factories']);
+            }
+
+            return;
+        }
+
+        if (file_exists($this->getModulePath() . '/Database/Factories')) {
+            $this->loadFactoriesFrom($this->getModulePath() . '/Database/Factories');
         }
     }
 
     private function registerRoutes(): void
     {
         if ($this->app->routesAreCached()) {
+            return;
+        }
+
+        $manifest = $this->getManifest();
+
+        if ($manifest !== null) {
+            foreach ($manifest['routes'] as $file) {
+                $fileName = basename($file);
+
+                if (in_array(rtrim($fileName, '.php'), static::ROUTE_FILE_TYPES) === false) {
+                    continue;
+                }
+
+                $this->loadRoutesFrom($file);
+            }
+
             return;
         }
 
@@ -266,6 +340,16 @@ abstract class Module extends ServiceProvider implements ModuleContract
                 $this->loadRoutesFrom($path);
             }
         }
+    }
+
+    protected function getManifest(): ?array
+    {
+        if (!$this->manifestLoaded) {
+            $this->manifestLoaded = true;
+            $this->cachedManifest = app(ModuleManifest::class)->get($this->getModuleNamespace());
+        }
+
+        return $this->cachedManifest;
     }
 
     /**

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -4,7 +4,10 @@ namespace Zonneplan\ModuleLoader;
 
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Zonneplan\ModuleLoader\Console\ModuleCacheCommand;
+use Zonneplan\ModuleLoader\Console\ModuleClearCommand;
 use Zonneplan\ModuleLoader\Support\Contracts\ModuleRepositoryContract;
+use Zonneplan\ModuleLoader\Support\ModuleManifest;
 use Zonneplan\ModuleLoader\Support\ModuleRepository;
 use Zonneplan\ModuleLoader\Support\ModuleRouteLoader;
 
@@ -18,6 +21,7 @@ class ModulesServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(ModuleRepositoryContract::class, ModuleRepository::class);
+        $this->app->singleton(ModuleManifest::class);
     }
 
     /**
@@ -36,5 +40,12 @@ class ModulesServiceProvider extends ServiceProvider
         Router::macro('modules', function (?string $type = 'routes') use ($loader) {
             $loader->loadAll($type);
         });
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ModuleCacheCommand::class,
+                ModuleClearCommand::class,
+            ]);
+        }
     }
 }

--- a/src/Support/ModuleManifest.php
+++ b/src/Support/ModuleManifest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Support;
+
+use Illuminate\Contracts\Foundation\Application;
+
+class ModuleManifest
+{
+    protected ?array $manifest = null;
+
+    public function __construct(
+        protected Application $app,
+    ) {
+    }
+
+    public function isCached(): bool
+    {
+        return file_exists($this->getCachePath());
+    }
+
+    public function get(string $moduleNamespace): ?array
+    {
+        if ($this->manifest === null) {
+            if (!$this->isCached()) {
+                return null;
+            }
+
+            $this->manifest = require $this->getCachePath();
+        }
+
+        return $this->manifest[$moduleNamespace] ?? null;
+    }
+
+    public function build(ModuleRepository $repository): array
+    {
+        $manifest = [];
+
+        foreach ($repository->getAll() as $namespace => $modulePath) {
+            $manifest[$namespace] = $this->scanModule($modulePath);
+        }
+
+        return $manifest;
+    }
+
+    public function write(array $manifest): void
+    {
+        $content = '<?php return ' . var_export($manifest, true) . ';' . PHP_EOL;
+
+        file_put_contents($this->getCachePath(), $content, LOCK_EX);
+
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($this->getCachePath(), true);
+        }
+    }
+
+    public function clear(): void
+    {
+        if ($this->isCached()) {
+            unlink($this->getCachePath());
+
+            if (function_exists('opcache_invalidate')) {
+                opcache_invalidate($this->getCachePath(), true);
+            }
+        }
+
+        $this->manifest = null;
+    }
+
+    public function getCachePath(): string
+    {
+        return $this->app->bootstrapPath('cache/modules.php');
+    }
+
+    protected function scanModule(string $modulePath): array
+    {
+        $migrationsPath = "{$modulePath}/Database/Migrations";
+        $viewsPath = "{$modulePath}/Resources/views";
+        $translationsPath = "{$modulePath}/Resources/lang";
+        $factoriesPath = "{$modulePath}/Database/Factories";
+
+        $configFiles = [];
+        $configPath = "{$modulePath}/Config";
+        if (is_dir($configPath)) {
+            $configFiles = glob("{$configPath}/*.php") ?: [];
+        }
+
+        $routeFiles = [];
+        $routesPath = "{$modulePath}/Routes";
+        if (is_dir($routesPath)) {
+            $routeFiles = glob("{$routesPath}/*.php") ?: [];
+        }
+
+        return [
+            'migrations' => is_dir($migrationsPath) ? $migrationsPath : null,
+            'views' => is_dir($viewsPath) ? $viewsPath : null,
+            'translations' => is_dir($translationsPath) ? $translationsPath : null,
+            'factories' => is_dir($factoriesPath) ? $factoriesPath : null,
+            'configs' => $configFiles,
+            'routes' => $routeFiles,
+        ];
+    }
+}

--- a/tests/Support/ModuleManifestTest.php
+++ b/tests/Support/ModuleManifestTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Test\Support;
+
+use Zonneplan\ModuleLoader\Support\ModuleManifest;
+use Zonneplan\ModuleLoader\Support\ModuleRepository;
+use Zonneplan\ModuleLoader\Test\TestCase;
+
+class ModuleManifestTest extends TestCase
+{
+    protected ModuleManifest $manifest;
+
+    protected string $modulesRoot;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manifest = app(ModuleManifest::class);
+        $this->manifest->clear();
+
+        $this->modulesRoot = sys_get_temp_dir() . '/module-loader-test-' . uniqid();
+    }
+
+    public function tearDown(): void
+    {
+        $this->manifest->clear();
+        $this->deleteDirectory($this->modulesRoot);
+
+        parent::tearDown();
+    }
+
+    public function test_it_is_not_cached_when_no_cache_file_exists()
+    {
+        $this->assertFalse($this->manifest->isCached());
+    }
+
+    public function test_it_returns_null_for_a_module_when_not_cached()
+    {
+        $this->assertNull($this->manifest->get('any-module'));
+    }
+
+    public function test_it_builds_a_manifest_by_scanning_module_paths()
+    {
+        $modulePath = $this->makeModule('full', [
+            'Database/Migrations',
+            'Resources/views',
+            'Resources/lang',
+            'Database/Factories',
+            'Config',
+            'Routes',
+        ], [
+            'Config/full.php' => '<?php return [];',
+            'Routes/web.php' => '<?php',
+        ]);
+
+        $repository = new ModuleRepository();
+        $repository->register('full', $modulePath);
+
+        $manifest = $this->manifest->build($repository);
+
+        $this->assertArrayHasKey('full', $manifest);
+        $this->assertSame([
+            'migrations' => "{$modulePath}/Database/Migrations",
+            'views' => "{$modulePath}/Resources/views",
+            'translations' => "{$modulePath}/Resources/lang",
+            'factories' => "{$modulePath}/Database/Factories",
+            'configs' => ["{$modulePath}/Config/full.php"],
+            'routes' => ["{$modulePath}/Routes/web.php"],
+        ], $manifest['full']);
+    }
+
+    public function test_it_sets_missing_directories_to_null_and_empty_file_lists()
+    {
+        $modulePath = $this->makeModule('empty', []);
+
+        $repository = new ModuleRepository();
+        $repository->register('empty', $modulePath);
+
+        $manifest = $this->manifest->build($repository);
+
+        $this->assertSame([
+            'migrations' => null,
+            'views' => null,
+            'translations' => null,
+            'factories' => null,
+            'configs' => [],
+            'routes' => [],
+        ], $manifest['empty']);
+    }
+
+    public function test_it_writes_a_cache_file_that_can_be_read_back()
+    {
+        $modulePath = $this->makeModule('writable', ['Resources/views']);
+
+        $repository = new ModuleRepository();
+        $repository->register('writable', $modulePath);
+
+        $built = $this->manifest->build($repository);
+
+        $this->assertFalse($this->manifest->isCached());
+
+        $this->manifest->write($built);
+
+        $this->assertTrue($this->manifest->isCached());
+        $this->assertFileExists($this->manifest->getCachePath());
+
+        // Resolve a fresh instance so the in-memory manifest is read from disk.
+        $fresh = new ModuleManifest($this->app);
+
+        $this->assertSame($built['writable'], $fresh->get('writable'));
+    }
+
+    public function test_it_returns_null_for_unknown_modules_when_cached()
+    {
+        $modulePath = $this->makeModule('known', []);
+
+        $repository = new ModuleRepository();
+        $repository->register('known', $modulePath);
+
+        $this->manifest->write($this->manifest->build($repository));
+
+        $fresh = new ModuleManifest($this->app);
+
+        $this->assertNotNull($fresh->get('known'));
+        $this->assertNull($fresh->get('does-not-exist'));
+    }
+
+    public function test_it_clears_the_cache_file()
+    {
+        $repository = new ModuleRepository();
+        $repository->register('clearable', $this->makeModule('clearable', []));
+
+        $this->manifest->write($this->manifest->build($repository));
+        $this->assertTrue($this->manifest->isCached());
+
+        $this->manifest->clear();
+
+        $this->assertFalse($this->manifest->isCached());
+        $this->assertFileDoesNotExist($this->manifest->getCachePath());
+        $this->assertNull($this->manifest->get('clearable'));
+    }
+
+    public function test_cache_path_points_to_the_bootstrap_cache_directory()
+    {
+        $this->assertSame(
+            $this->app->bootstrapPath('cache/modules.php'),
+            $this->manifest->getCachePath()
+        );
+    }
+
+    /**
+     * Create a module fixture with the given sub-directories and files.
+     *
+     * @param array<int, string> $directories
+     * @param array<string, string> $files
+     */
+    private function makeModule(string $name, array $directories, array $files = []): string
+    {
+        $modulePath = "{$this->modulesRoot}/{$name}";
+
+        mkdir($modulePath, 0777, true);
+
+        foreach ($directories as $directory) {
+            mkdir("{$modulePath}/{$directory}", 0777, true);
+        }
+
+        foreach ($files as $relativePath => $contents) {
+            file_put_contents("{$modulePath}/{$relativePath}", $contents);
+        }
+
+        return $modulePath;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
  New files:                                                                                                                                                                                                                                      
  - src/Support/ModuleManifest.php — reads/writes the manifest at bootstrap/cache/modules.php. Single file_exists + require on first access, then pure array lookups.
  - src/Console/ModuleCacheCommand.php — php artisan module:cache scans all registered modules and writes the manifest                                                                                                                              
  - src/Console/ModuleClearCommand.php — php artisan module:clear deletes the manifest
                                                                                                                                                                                                                                                    
  Modified files:                                                                                                                                                                                                                                 
  - src/ModulesServiceProvider.php — registers ModuleManifest as singleton + the two commands
  - src/Module.php — every loader method (loadMigrations, loadViews, loadTranslations, loadConfigs, registerFactories, registerRoutes) now checks the manifest first. If cached, uses the pre-scanned paths (zero file_exists/glob calls). Falls
  back to the original behavior when no manifest exists.

  Performance impact with 200 modules:
  - Without manifest: ~1200 stat calls + ~400 glob calls per request
  - With manifest: 1 file_exists + 1 require total (the manifest file), then pure in-memory array lookups

  Usage:
  php artisan module:cache   # generate after deploy
  php artisan module:clear   # clear during development
