### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | 10.0  | ^4.0                     |
 | 11.0  | ^5.0                     |
 | 12.0  | ^6.0                     |
-| 13.0  | ^6.0                     |
+| 13.0  | ^7.0                     |
 
 The `zonneplan/laravel-module-loader` package provides an easy to use module loader 
 which can be used to modulize your project.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | 10.0  | ^4.0                     |
 | 11.0  | ^5.0                     |
 | 12.0  | ^6.0                     |
+| 13.0  | ^6.0                     |
 
 The `zonneplan/laravel-module-loader` package provides an easy to use module loader 
 which can be used to modulize your project.

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
     "authors": [],
     "require": {
         "php": "^8.2",
-        "illuminate/console": "^11.0||^12.0",
-        "illuminate/database": "^11.0||^12.0",
-        "illuminate/support": "^11.0||^12.0",
-        "illuminate/routing": "^11.0||^12.0"
+        "illuminate/console": "^11.0||^12.0||^13.0",
+        "illuminate/database": "^11.0||^12.0||^13.0",
+        "illuminate/support": "^11.0||^12.0||^13.0",
+        "illuminate/routing": "^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0||^11.0",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0||^10.0"
+        "orchestra/testbench": "^9.0||^10.0||^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Add `^13.0` to all `illuminate/*` dependency constraints
- Add `^11.0` to `orchestra/testbench` for Laravel 13 compatibility
- Update README compatibility table

## Test plan
- [ ] Verify package installs with Laravel 13
- [ ] Run existing test suite against Laravel 13