### PR TITLE
feat: add module loading profiling functionality and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,32 @@ Any of the following files will be auto loaded:
 
 `routes.php` `api.php` `web.php` `mcp.php`
 
+#### Profiling module loading:
+Module loading profiling is disabled by default. Publish the config file to enable it:
+
+``` bash
+php artisan vendor:publish --tag=module-loader-config
+```
+
+The following environment variables are available:
+
+``` dotenv
+MODULE_LOADER_PROFILING_ENABLED=false
+MODULE_LOADER_PROFILING_DRIVER=log
+MODULE_LOADER_PROFILING_INCLUDE_STEPS=false
+MODULE_LOADER_PROFILING_LOG_CHANNEL=null
+```
+
+Supported drivers:
+
+- `log`: writes structured timing records to the configured Laravel log channel.
+- `callback`: calls `module-loader.profiling.reporter`, which may be a callable or a class with a `handle(array $measurement)` method.
+- `event`: dispatches a `Zonneplan\ModuleLoader\Events\ModuleProfiled` event with the measurement.
+
+The base `register()` and `boot()` methods are profiled when enabled. If `include_steps` is enabled, the built-in boot steps like config, translation, view, policy, route, and middleware loading are profiled separately.
+
+OpenTelemetry is intentionally not a dependency of this package. Applications that want OpenTelemetry spans can install `open-telemetry/api` and convert profiling measurements to spans from a callback reporter or a `ModuleProfiled` listener.
+
 ## Requirements
 
 This package requires at least Laravel 6 or higher, PHP 7.2 or higher 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^9.0||^10.0||^11.0"
     },
+    "suggest": {
+        "open-telemetry/api": "Allows applications to convert module profiling measurements to OpenTelemetry spans using the callback or event driver."
+    },
     "autoload": {
         "psr-4": {
             "Zonneplan\\ModuleLoader\\": "src"

--- a/config/module-loader.php
+++ b/config/module-loader.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'profiling' => [
+        'enabled' => env('MODULE_LOADER_PROFILING_ENABLED', false),
+        'driver' => env('MODULE_LOADER_PROFILING_DRIVER', 'log'),
+        'include_steps' => env('MODULE_LOADER_PROFILING_INCLUDE_STEPS', false),
+        'log_channel' => env('MODULE_LOADER_PROFILING_LOG_CHANNEL'),
+        'reporter' => null,
+    ],
+];

--- a/src/Events/ModuleProfiled.php
+++ b/src/Events/ModuleProfiled.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Events;
+
+class ModuleProfiled
+{
+    public function __construct(
+        public array $measurement
+    ) {
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -11,6 +11,7 @@ use ReflectionClass;
 use ReflectionException;
 use Zonneplan\ModuleLoader\Support\Contracts\ModuleContract;
 use Zonneplan\ModuleLoader\Support\Contracts\ModuleRepositoryContract;
+use Zonneplan\ModuleLoader\Support\Profiling\ModuleProfiler;
 
 /**
  * Class ModuleLoader.
@@ -46,8 +47,10 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     public function register(): void
     {
-        // Register this module in the repository
-        app(ModuleRepositoryContract::class)->register($this->getModuleNamespace(), $this->getModulePath());
+        $this->profile('register', function (): void {
+            // Register this module in the repository
+            app(ModuleRepositoryContract::class)->register($this->getModuleNamespace(), $this->getModulePath());
+        });
     }
 
     /**
@@ -58,20 +61,60 @@ abstract class Module extends ServiceProvider implements ModuleContract
      */
     public function boot(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->registerCommands();
-            $this->loadCommandSchedule();
-            $this->loadMigrations();
-            $this->registerFactories();
+        $this->profile('boot', function (): void {
+            if ($this->app->runningInConsole()) {
+                $this->profileStep('boot.registerCommands', function (): void {
+                    $this->registerCommands();
+                });
+                $this->profileStep('boot.loadCommandSchedule', function (): void {
+                    $this->loadCommandSchedule();
+                });
+                $this->profileStep('boot.loadMigrations', function (): void {
+                    $this->loadMigrations();
+                });
+                $this->profileStep('boot.registerFactories', function (): void {
+                    $this->registerFactories();
+                });
+            }
+
+            $this->profileStep('boot.loadConfigs', function (): void {
+                $this->loadConfigs();
+            });
+            $this->profileStep('boot.loadTranslations', function (): void {
+                $this->loadTranslations();
+            });
+            $this->profileStep('boot.registerListeners', function (): void {
+                $this->registerListeners();
+            });
+            $this->profileStep('boot.loadViews', function (): void {
+                $this->loadViews();
+            });
+            $this->profileStep('boot.registerPolicies', function (): void {
+                $this->registerPolicies();
+            });
+            $this->profileStep('boot.registerRoutes', function (): void {
+                $this->registerRoutes();
+            });
+            $this->profileStep('boot.registerMiddleware', function (): void {
+                $this->registerMiddleware();
+            });
+        });
+    }
+
+    protected function profile(string $operation, callable $callback): mixed
+    {
+        return app(ModuleProfiler::class)->record($this, $operation, $callback);
+    }
+
+    protected function profileStep(string $operation, callable $callback): mixed
+    {
+        $profiler = app(ModuleProfiler::class);
+
+        if (! $profiler->shouldProfileSteps()) {
+            return $callback();
         }
 
-        $this->loadConfigs();
-        $this->loadTranslations();
-        $this->registerListeners();
-        $this->loadViews();
-        $this->registerPolicies();
-        $this->registerRoutes();
-        $this->registerMiddleware();
+        return $profiler->record($this, $operation, $callback);
     }
 
     /**

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -17,6 +17,8 @@ class ModulesServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/module-loader.php', 'module-loader');
+
         $this->app->singleton(ModuleRepositoryContract::class, ModuleRepository::class);
     }
 
@@ -27,6 +29,10 @@ class ModulesServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->publishes([
+            __DIR__ . '/../config/module-loader.php' => config_path('module-loader.php'),
+        ], 'module-loader-config');
+
         $loader = new ModuleRouteLoader();
 
         Router::macro('module', function (string $name, ?string $type = 'routes') use ($loader) {

--- a/src/Support/Contracts/ModuleRepositoryContract.php
+++ b/src/Support/Contracts/ModuleRepositoryContract.php
@@ -4,4 +4,11 @@ namespace Zonneplan\ModuleLoader\Support\Contracts;
 
 interface ModuleRepositoryContract
 {
+    public function register(string $module, string $path): self;
+
+    public function getAll(): array;
+
+    public function isLoaded(string $module): bool;
+
+    public function get(string $module): string;
 }

--- a/src/Support/ModuleRouteLoader.php
+++ b/src/Support/ModuleRouteLoader.php
@@ -62,10 +62,7 @@ class ModuleRouteLoader
         }
     }
 
-    /**
-     * @return ModuleRepository
-     */
-    protected function getRepository(): ModuleRepository
+    protected function getRepository(): ModuleRepositoryContract
     {
         return app(ModuleRepositoryContract::class);
     }

--- a/src/Support/Profiling/ModuleProfiler.php
+++ b/src/Support/Profiling/ModuleProfiler.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Support\Profiling;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+use Zonneplan\ModuleLoader\Events\ModuleProfiled;
+use Zonneplan\ModuleLoader\Support\Contracts\ModuleContract;
+
+class ModuleProfiler
+{
+    public function record(ModuleContract $module, string $operation, callable $callback): mixed
+    {
+        if (! $this->isEnabled()) {
+            return $callback();
+        }
+
+        $startedAt = hrtime(true);
+        $exception = null;
+
+        try {
+            return $callback();
+        } catch (Throwable $throwable) {
+            $exception = $throwable;
+
+            throw $throwable;
+        } finally {
+            $this->report($module, $operation, hrtime(true) - $startedAt, $exception);
+        }
+    }
+
+    public function shouldProfileSteps(): bool
+    {
+        return $this->isEnabled() && (bool) config('module-loader.profiling.include_steps', false);
+    }
+
+    private function isEnabled(): bool
+    {
+        return (bool) config('module-loader.profiling.enabled', false);
+    }
+
+    private function driver(): string
+    {
+        return (string) config('module-loader.profiling.driver', 'log');
+    }
+
+    private function report(ModuleContract $module, string $operation, int $durationNanoseconds, ?Throwable $exception): void
+    {
+        $measurement = $this->measurement($module, $operation, $durationNanoseconds, $exception);
+
+        if ($this->driver() === 'callback') {
+            $this->reportUsingCallback($measurement);
+
+            return;
+        }
+
+        if ($this->driver() === 'event') {
+            Event::dispatch(new ModuleProfiled($measurement));
+
+            return;
+        }
+
+        if ($this->driver() !== 'log') {
+            return;
+        }
+
+        $channel = config('module-loader.profiling.log_channel');
+
+        if ($channel) {
+            Log::channel($channel)->debug('Module loader profiling', $measurement);
+
+            return;
+        }
+
+        Log::debug('Module loader profiling', $measurement);
+    }
+
+    private function reportUsingCallback(array $measurement): void
+    {
+        $reporter = config('module-loader.profiling.reporter');
+
+        if (is_string($reporter)) {
+            app($reporter)->handle($measurement);
+
+            return;
+        }
+
+        if (is_callable($reporter)) {
+            $reporter($measurement);
+        }
+    }
+
+    private function measurement(ModuleContract $module, string $operation, int $durationNanoseconds, ?Throwable $exception): array
+    {
+        $measurement = [
+            'module' => $module->getModuleNamespace(),
+            'provider' => $module::class,
+            'operation' => $operation,
+            'duration_ms' => round($durationNanoseconds / 1_000_000, 3),
+            'duration_ns' => $durationNanoseconds,
+        ];
+
+        if ($exception) {
+            $measurement['exception'] = $exception::class;
+            $measurement['exception_message'] = $exception->getMessage();
+        }
+
+        return $measurement;
+    }
+}

--- a/tests/Support/ModuleProfilingTest.php
+++ b/tests/Support/ModuleProfilingTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Zonneplan\ModuleLoader\Test\Support;
+
+use Illuminate\Support\Facades\Event;
+use Zonneplan\ModuleLoader\Events\ModuleProfiled;
+use Zonneplan\ModuleLoader\Module;
+use Zonneplan\ModuleLoader\Test\TestCase;
+
+class ModuleProfilingTest extends TestCase
+{
+    public function test_it_does_not_profile_modules_by_default()
+    {
+        $records = [];
+
+        config([
+            'module-loader.profiling.enabled' => false,
+            'module-loader.profiling.driver' => 'callback',
+            'module-loader.profiling.reporter' => function (array $measurement) use (&$records): void {
+                $records[] = $measurement;
+            },
+        ]);
+
+        $module = new ProfilingTestModule($this->app);
+
+        $module->register();
+        $module->boot();
+
+        $this->assertEmpty($records);
+    }
+
+    public function test_it_profiles_module_register_and_boot_when_enabled()
+    {
+        $records = [];
+
+        config([
+            'module-loader.profiling.enabled' => true,
+            'module-loader.profiling.driver' => 'callback',
+            'module-loader.profiling.include_steps' => false,
+            'module-loader.profiling.reporter' => function (array $measurement) use (&$records): void {
+                $records[] = $measurement;
+            },
+        ]);
+
+        $module = new ProfilingTestModule($this->app);
+
+        $module->register();
+        $module->boot();
+
+        $this->assertEquals(['register', 'boot'], array_column($records, 'operation'));
+        $this->assertSame(['profiling-test', 'profiling-test'], array_column($records, 'module'));
+        $this->assertSame([ProfilingTestModule::class, ProfilingTestModule::class], array_column($records, 'provider'));
+        $this->assertArrayHasKey('duration_ms', $records[0]);
+        $this->assertArrayHasKey('duration_ns', $records[0]);
+    }
+
+    public function test_it_profiles_module_boot_steps_when_enabled()
+    {
+        $records = [];
+
+        config([
+            'module-loader.profiling.enabled' => true,
+            'module-loader.profiling.driver' => 'callback',
+            'module-loader.profiling.include_steps' => true,
+            'module-loader.profiling.reporter' => function (array $measurement) use (&$records): void {
+                $records[] = $measurement;
+            },
+        ]);
+
+        $module = new ProfilingTestModule($this->app);
+
+        $module->boot();
+
+        $operations = array_column($records, 'operation');
+
+        $this->assertContains('boot', $operations);
+        $this->assertContains('boot.loadConfigs', $operations);
+        $this->assertContains('boot.loadTranslations', $operations);
+        $this->assertContains('boot.registerRoutes', $operations);
+    }
+
+    public function test_it_can_dispatch_profile_measurements_as_events()
+    {
+        Event::fake([
+            ModuleProfiled::class,
+        ]);
+
+        config([
+            'module-loader.profiling.enabled' => true,
+            'module-loader.profiling.driver' => 'event',
+            'module-loader.profiling.include_steps' => false,
+        ]);
+
+        $module = new ProfilingTestModule($this->app);
+
+        $module->register();
+
+        Event::assertDispatched(ModuleProfiled::class, function (ModuleProfiled $event): bool {
+            return $event->measurement['module'] === 'profiling-test'
+                && $event->measurement['provider'] === ProfilingTestModule::class
+                && $event->measurement['operation'] === 'register'
+                && array_key_exists('duration_ms', $event->measurement)
+                && array_key_exists('duration_ns', $event->measurement);
+        });
+    }
+}
+
+class ProfilingTestModule extends Module
+{
+    public function getModuleNamespace(): string
+    {
+        return 'profiling-test';
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in profiling for module loading.

This introduces configurable profiling around module `register()` and `boot()` calls, with optional step-level timings for the built-in boot operations such as config, translation, view, policy, route, and middleware loading.

## Details

- Adds publishable `module-loader.php` config
- Keeps profiling disabled by default
- Supports `log`, `callback`, and `event` profiling drivers
- Dispatches `ModuleProfiled` events for custom integrations
- Adds Composer `suggest` for `open-telemetry/api` without making it a dependency
- Updates `ModuleRepositoryContract` to declare its public API
- Documents the profiling feature in the README
- Adds PHPUnit coverage for disabled profiling, callback profiling, step profiling, and event dispatching

## Testing

- `./vendor/bin/phpunit`
- `composer validate --strict`
