### PR TITLE
feat: add sampling rate for module profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The following environment variables are available:
 MODULE_LOADER_PROFILING_ENABLED=false
 MODULE_LOADER_PROFILING_DRIVER=log
 MODULE_LOADER_PROFILING_INCLUDE_STEPS=false
+MODULE_LOADER_PROFILING_SAMPLE_RATE=1.0
 MODULE_LOADER_PROFILING_LOG_CHANNEL=null
 ```
 
@@ -164,7 +165,7 @@ Supported drivers:
 - `callback`: calls `module-loader.profiling.reporter`, which may be a callable or a class with a `handle(array $measurement)` method.
 - `event`: dispatches a `Zonneplan\ModuleLoader\Events\ModuleProfiled` event with the measurement.
 
-The base `register()` and `boot()` methods are profiled when enabled. If `include_steps` is enabled, the built-in boot steps like config, translation, view, policy, route, and middleware loading are profiled separately.
+The base `register()` and `boot()` methods are profiled when enabled. If `include_steps` is enabled, the built-in boot steps like config, translation, view, policy, route, and middleware loading are profiled separately. The `sample_rate` value is evaluated once per request or process, so sampled runs keep a complete module loading profile.
 
 OpenTelemetry is intentionally not a dependency of this package. Applications that want OpenTelemetry spans can install `open-telemetry/api` and convert profiling measurements to spans from a callback reporter or a `ModuleProfiled` listener.
 

--- a/config/module-loader.php
+++ b/config/module-loader.php
@@ -5,6 +5,7 @@ return [
         'enabled' => env('MODULE_LOADER_PROFILING_ENABLED', false),
         'driver' => env('MODULE_LOADER_PROFILING_DRIVER', 'log'),
         'include_steps' => env('MODULE_LOADER_PROFILING_INCLUDE_STEPS', false),
+        'sample_rate' => env('MODULE_LOADER_PROFILING_SAMPLE_RATE', 1.0),
         'log_channel' => env('MODULE_LOADER_PROFILING_LOG_CHANNEL'),
         'reporter' => null,
     ],

--- a/src/Support/Profiling/ModuleProfiler.php
+++ b/src/Support/Profiling/ModuleProfiler.php
@@ -10,9 +10,11 @@ use Zonneplan\ModuleLoader\Support\Contracts\ModuleContract;
 
 class ModuleProfiler
 {
+    private ?bool $shouldSample = null;
+
     public function record(ModuleContract $module, string $operation, callable $callback): mixed
     {
-        if (! $this->isEnabled()) {
+        if (! $this->shouldProfile()) {
             return $callback();
         }
 
@@ -32,7 +34,12 @@ class ModuleProfiler
 
     public function shouldProfileSteps(): bool
     {
-        return $this->isEnabled() && (bool) config('module-loader.profiling.include_steps', false);
+        return $this->shouldProfile() && (bool) config('module-loader.profiling.include_steps', false);
+    }
+
+    private function shouldProfile(): bool
+    {
+        return $this->isEnabled() && $this->shouldSample();
     }
 
     private function isEnabled(): bool
@@ -43,6 +50,25 @@ class ModuleProfiler
     private function driver(): string
     {
         return (string) config('module-loader.profiling.driver', 'log');
+    }
+
+    private function shouldSample(): bool
+    {
+        if ($this->shouldSample !== null) {
+            return $this->shouldSample;
+        }
+
+        $sampleRate = max(0.0, min(1.0, (float) config('module-loader.profiling.sample_rate', 1.0)));
+
+        if ($sampleRate >= 1.0) {
+            return $this->shouldSample = true;
+        }
+
+        if ($sampleRate <= 0.0) {
+            return $this->shouldSample = false;
+        }
+
+        return $this->shouldSample = random_int(1, 1_000_000) <= (int) round($sampleRate * 1_000_000);
     }
 
     private function report(ModuleContract $module, string $operation, int $durationNanoseconds, ?Throwable $exception): void

--- a/tests/Support/ModuleProfilingTest.php
+++ b/tests/Support/ModuleProfilingTest.php
@@ -79,6 +79,55 @@ class ModuleProfilingTest extends TestCase
         $this->assertContains('boot.registerRoutes', $operations);
     }
 
+    public function test_it_skips_module_profiling_when_request_is_not_sampled()
+    {
+        $records = [];
+
+        config([
+            'module-loader.profiling.enabled' => true,
+            'module-loader.profiling.driver' => 'callback',
+            'module-loader.profiling.include_steps' => true,
+            'module-loader.profiling.sample_rate' => 0.0,
+            'module-loader.profiling.reporter' => function (array $measurement) use (&$records): void {
+                $records[] = $measurement;
+            },
+        ]);
+
+        $module = new ProfilingTestModule($this->app);
+
+        $module->register();
+        $module->boot();
+
+        $this->assertEmpty($records);
+    }
+
+    public function test_it_profiles_all_module_measurements_when_request_is_sampled()
+    {
+        $records = [];
+
+        config([
+            'module-loader.profiling.enabled' => true,
+            'module-loader.profiling.driver' => 'callback',
+            'module-loader.profiling.include_steps' => true,
+            'module-loader.profiling.sample_rate' => 1.0,
+            'module-loader.profiling.reporter' => function (array $measurement) use (&$records): void {
+                $records[] = $measurement;
+            },
+        ]);
+
+        $module = new ProfilingTestModule($this->app);
+
+        $module->register();
+        $module->boot();
+
+        $operations = array_column($records, 'operation');
+
+        $this->assertContains('register', $operations);
+        $this->assertContains('boot', $operations);
+        $this->assertContains('boot.loadConfigs', $operations);
+        $this->assertContains('boot.registerRoutes', $operations);
+    }
+
     public function test_it_can_dispatch_profile_measurements_as_events()
     {
         Event::fake([


### PR DESCRIPTION
## Summary

- Add a configurable `profiling.sample_rate` option.
- Evaluate the profiling sample decision once per request/process.
- Skip module profiling before timing/reporting starts when a run is not sampled.
- Document the new sampling option in the published config/README.

## Notes

Sampling is run-level, not measurement-level. A sampled run keeps a complete module loading profile, while an unsampled run skips profiling overhead entirely.

Example published config:

```php
'profiling' => [
    'enabled' => true,
    'include_steps' => true,
    'sample_rate' => 0.1,
],
```

With this configuration, about 10% of runs include complete module-loader profiling data.

## Verification

- `./vendor/bin/phpunit`
- `composer validate --strict`